### PR TITLE
Compiling for MacOS arm64 targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ build: $(NIF_SO_REL)
 
 priv_dir:
 	@ if [ ! -e "$(PRIV_DIR)" ]; then \
- 		mkdir -p "$(PRIV_DIR)" ; \
- 	fi
+		mkdir -p "$(PRIV_DIR)" ; \
+	fi
 
 adbc: priv_dir
 	@ if [ ! -f "$(ADBC_DRIVER_COMMON_LIB)" ]; then \
@@ -57,8 +57,9 @@ adbc: priv_dir
 			-DCMAKE_BUILD_TYPE="$(CMAKE_BUILD_TYPE)" \
 			-DCMAKE_INSTALL_PREFIX="$(PRIV_DIR)" \
 			-DADBC_DEPENDENCY_SOURCE=BUNDLED \
+			-DCMAKE_OSX_ARCHITECTURES=arm64 \
 			$(CMAKE_CONFIGURE_FLAGS) $(CMAKE_ADBC_OPTIONS) "$(ADBC_C_SRC)" && \
-    	cmake --build . --target install -j ; \
+		cmake --build . --target install -j ; \
 	fi
 
 $(NIF_SO_REL): priv_dir adbc $(C_SRC_REL)/adbc_nif_resource.hpp $(C_SRC_REL)/adbc_nif.cpp $(C_SRC_REL)/nif_utils.hpp $(C_SRC_REL)/nif_utils.cpp
@@ -71,6 +72,7 @@ $(NIF_SO_REL): priv_dir adbc $(C_SRC_REL)/adbc_nif_resource.hpp $(C_SRC_REL)/adb
 		-D MIX_APP_PATH="$(MIX_APP_PATH)" \
 		-D PRIV_DIR="$(PRIV_DIR)" \
 		-D ERTS_INCLUDE_DIR="$(ERTS_INCLUDE_DIR)" \
+		-DCMAKE_OSX_ARCHITECTURES=arm64 \
 		$(CMAKE_CONFIGURE_FLAGS) $(CMAKE_ADBC_NIF_OPTIONS) "$(shell pwd)" && \
 	make "$(MAKE_BUILD_FLAGS)" && \
 	cp "$(CMAKE_ADBC_NIF_BUILD_DIR)/adbc_nif.so" "$(NIF_SO)"


### PR DESCRIPTION
Until now, the project did not compile on my MacOS M1 laptop.
It worked perfectly fine on my old x86-64 Linux laptop, but I wanted to try to make it compile properly on my current laptop as well.

After some trial and error, I've figured out that the proper way to do this, seems to be to pass the option `CMAKE_OSX_ARCHITECTURES=arm64` to `cmake`.

What I don't know, however, is what the best way to set this setting properly on the actual device the `Makefile` ends up executing on.

Any ideas?