### PR TITLE
WIP: automated cleanup of NifRes using RAII

### DIFF
--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -958,49 +958,49 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
 
     {
         using res_type = NifRes<struct AdbcDatabase>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcDatabase", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcDatabase", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct AdbcConnection>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcConnection", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcConnection", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct AdbcStatement>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcStatement", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcStatement", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct AdbcError>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcError", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcError", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct ArrowArrayStream>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArrayStream", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArrayStream", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct ArrowArray>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArray", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArray", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct ArrowSchema>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowSchema", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowSchema", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -958,49 +958,49 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
 
     {
         using res_type = NifRes<struct AdbcDatabase>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcDatabase", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcDatabase", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct AdbcConnection>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcConnection", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcConnection", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct AdbcStatement>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcStatement", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcStatement", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct AdbcError>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcError", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResAdbcError", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct ArrowArrayStream>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArrayStream", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArrayStream", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct ArrowArray>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArray", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowArray", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }
 
     {
         using res_type = NifRes<struct ArrowSchema>;
-        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowSchema", adbc_destruct_resource<res_type::val_type>, ERL_NIF_RT_CREATE, NULL);
+        rt = enif_open_resource_type(env, "Elixir.Adbc.Nif", "NifResArrowSchema", res_type::destruct_resource, ERL_NIF_RT_CREATE, NULL);
         if (!rt) return -1;
         res_type::type = rt;
     }

--- a/c_src/adbc_nif_resource.hpp
+++ b/c_src/adbc_nif_resource.hpp
@@ -3,6 +3,7 @@
 
 #include <erl_nif.h>
 #include <atomic>
+#include <memory>
 #include <adbc.h>
 
 // Only for debugging:

--- a/c_src/adbc_nif_resource.hpp
+++ b/c_src/adbc_nif_resource.hpp
@@ -20,7 +20,7 @@ template <typename T, typename = void>
 struct release_guard : std::false_type {};
 
 template <typename T>
-struct release_guard<T, void_t<decltype(T::release)>> : std::true_type {};
+struct release_guard<T, typename std::enable_if<std::is_same<decltype(T::release), void(*)(T*)>::value>::type> : std::true_type {};
 
 /// A NifRes<T> wraps a `T` to allow it to be shared between C++ and Erlang while managing its lifetime properly.
 ///

--- a/c_src/adbc_nif_resource.hpp
+++ b/c_src/adbc_nif_resource.hpp
@@ -10,11 +10,16 @@
 
 template<typename T> struct NoOpDeleter;
 
-/// A NifRes<T> wraps a `T` to allow it to be shared between C++, Erlang. and possibly NIFs written in other languages as well .
+/// A NifRes<T> wraps a `T` to allow it to be shared between C++ and Erlang while managing its lifetime properly.
 ///
 /// Because the in-memory representation of a `*NifRes<T>` is the same as a `*T`,
 /// the result from `my_nif_res->get_resource()` can be passed to a NIF
 /// written in other languages as well (as long as they know the memory representation of T).
+///
+/// Lifetime is managed automatically by:
+/// - Returning an owned pointer from `allocate_resource` and `clone_ref`. Behind the scenes, these calls manipulate Erlang's refcount of the resource object.
+/// - Whenever one of these owned pointers leaves the scope, the refcount is decremented.
+/// - Separately, a `destruct_resource` callback is provided to Erlang which will be called by the GC when there are no references (from either Erlang or C++ side) remaining.
 template <typename T>
 struct NifRes {
     using val_type_p = T *;


### PR DESCRIPTION


The idea behind this PR is to manage the setup and cleanup of `NifRes<T>`'s automatically, using C++'s builtin scope-based construction/destruction functionality (AKA [RAII](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization)).

This allows us to remove all manual calls to `enif_release_resource` in the code, making it less error-prone to use NifRes/harder to accidentally leak memory.

---

This PR is a work-in-progress. Things that need to happen before merging:

- I'm still thinking whether there is a nicer approach rather than using `unique_ptr` with a custom deleter.
- I want to add some tests.
- Remove the debug print statements that are currently in the source 😜 