### PR TITLE
[WIP] Implement `ArrowArrayStream`, `ArrowSchema` and `ArrowArray`

### DIFF
--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -195,6 +195,10 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
     if (has_validity_bitmap && values->n_buffers >= 2) {
         bitmap_buffer = (const uint8_t *)values->buffers[0];
     }
+    const int32_t * offsets_buffer = nullptr;
+    if (values->n_buffers >= 3) {
+        offsets_buffer = (const int32_t *)values->buffers[1];
+    }
 
     bool is_struct = false;
     if (strncmp("l", format, 1) == 0) {
@@ -205,6 +209,78 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
             bitmap_buffer,
             (const value_type *)values->buffers[1],
             enif_make_int64
+        );
+    } else if (strncmp("c", format, 1) == 0) {
+        using value_type = int8_t;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_int64
+        );
+    } else if (strncmp("s", format, 1) == 0) {
+        using value_type = int16_t;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_int64
+        );
+    } else if (strncmp("i", format, 1) == 0) {
+        using value_type = int32_t;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_int64
+        );
+    } else if (strncmp("L", format, 1) == 0) {
+        using value_type = uint64_t;
+        current_term = values_from_buffer(
+            env,
+            values->length, 
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_uint64
+        );
+    } else if (strncmp("C", format, 1) == 0) {
+        using value_type = uint8_t;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_uint64
+        );
+    } else if (strncmp("S", format, 1) == 0) {
+        using value_type = uint16_t;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_uint64
+        );
+    } else if (strncmp("I", format, 1) == 0) {
+        using value_type = uint32_t;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_uint64
+        );
+    } else if (strncmp("f", format, 1) == 0) {
+        using value_type = float;
+        current_term = values_from_buffer(
+            env,
+            values->length,
+            bitmap_buffer,
+            (const value_type *)values->buffers[1],
+            enif_make_double
         );
     } else if (strncmp("g", format, 1) == 0) {
         using value_type = double;
@@ -221,7 +297,7 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
             env,
             values->length,
             bitmap_buffer,
-            (const int32_t *)values->buffers[1],
+            offsets_buffer,
             (const uint8_t *)values->buffers[2],
             [](ErlNifEnv *env, const uint8_t * string_buffers, int32_t offset, size_t nbytes) -> ERL_NIF_TERM {
                 return erlang::nif::make_binary(env, (const char *)(string_buffers + offset), nbytes);

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -640,7 +640,8 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_schema(ErlNifEnv *env, int argc,
 
     int code = res->val.get_schema(&res->val, &schema->val);
     if (code != 0) {
-        return erlang::nif::error(env, strerror(code));
+        const char * reason = res->val.get_last_error(&res->val);
+        return erlang::nif::error(env, reason ? reason : "unknown error");
     }
 
     ret = schema->make_resource(env);

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -478,7 +478,7 @@ static ERL_NIF_TERM adbc_connection_get_table_schema(ErlNifEnv *env, int argc, c
         return nif_error_from_adbc_error(env, &adbc_error);
     }
 
-    ERL_NIF_TERM ret = schema->make_resource(env);
+    ret = schema->make_resource(env);
     nif_schema = arrow_schema_to_nif_term(env, &schema->val);
     return enif_make_tuple3(env, 
         erlang::nif::ok(env),
@@ -629,8 +629,8 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_schema(ErlNifEnv *env, int argc,
         return error;
     }
 
-    schema_type * schema = nullptr;
-    if ((schema = schema_type::allocate_resource(env, error)) == nullptr) {
+    auto schema = schema_type::allocate_resource(env, error);
+    if (schema == nullptr) {
         return error;
     }
 
@@ -643,9 +643,8 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_schema(ErlNifEnv *env, int argc,
         return erlang::nif::error(env, strerror(code));
     }
 
-    ret = enif_make_resource(env, schema);
+    ret = schema->make_resource(env);
     nif_schema = arrow_schema_to_nif_term(env, &schema->val);
-    enif_release_resource(schema);
 
     return enif_make_tuple3(env, 
         erlang::nif::ok(env),

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -232,13 +232,12 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
         is_struct = true;
     } else {
         printf("not implemented for format: `%s`\r\n", schema->format);
-        printf("has_validity_bitmap: %d\r\n", has_validity_bitmap);
-        printf("length: %lld\r\n", values->length);
-        printf("null_count: %lld\r\n", values->null_count);
-        printf("offset: %lld\r\n", values->offset);
-        printf("n_buffers: %lld\r\n", values->n_buffers);
-        printf("n_children: %lld\r\n", values->n_children);
-        printf("buffers: %p\r\n", values->buffers);
+        // printf("length: %lld\r\n", values->length);
+        // printf("null_count: %lld\r\n", values->null_count);
+        // printf("offset: %lld\r\n", values->offset);
+        // printf("n_buffers: %lld\r\n", values->n_buffers);
+        // printf("n_children: %lld\r\n", values->n_children);
+        // printf("buffers: %p\r\n", values->buffers);
     }
 
     if (is_struct) {

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -654,23 +654,6 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_schema(ErlNifEnv *env, int argc,
     );
 }
 
-static ERL_NIF_TERM adbc_arrow_array_stream_reset(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct ArrowArrayStream>;
-    ERL_NIF_TERM ret{};
-    ERL_NIF_TERM error{};
-
-    res_type * res = nullptr;
-    if ((res = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    if (res->val.release) {
-        res->val.release(&res->val);
-    }
-
-    return erlang::nif::ok(env);
-}
-
 static ERL_NIF_TERM adbc_error_new(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     using res_type = NifRes<struct AdbcError>;
     ERL_NIF_TERM error{};

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -653,6 +653,23 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_schema(ErlNifEnv *env, int argc,
     );
 }
 
+static ERL_NIF_TERM adbc_arrow_array_stream_release(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using res_type = NifRes<struct ArrowArrayStream>;
+    ERL_NIF_TERM error{};
+
+    res_type * res = nullptr;
+    if ((res = res_type::get_resource(env, argv[0], error)) == nullptr) {
+        return error;
+    }
+
+    if (res->val.release) {
+        res->val.release(&res->val);
+        res->val.release = nullptr;
+    }
+
+    return erlang::nif::ok(env);
+}
+
 static ERL_NIF_TERM adbc_error_new(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     using res_type = NifRes<struct AdbcError>;
     ERL_NIF_TERM error{};
@@ -1142,6 +1159,7 @@ static ErlNifFunc nif_functions[] = {
 
     {"adbc_arrow_array_stream_get_pointer", 1, adbc_arrow_array_stream_get_pointer, 0},
     {"adbc_arrow_array_stream_get_schema", 1, adbc_arrow_array_stream_get_schema, 0},
+    {"adbc_arrow_array_stream_release", 1, adbc_arrow_array_stream_release, 0},
 
     {"adbc_error_new", 0, adbc_error_new, 0},
     {"adbc_error_reset", 1, adbc_error_reset, 0},

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -654,6 +654,30 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_schema(ErlNifEnv *env, int argc,
     );
 }
 
+static ERL_NIF_TERM adbc_arrow_array_stream_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using res_type = NifRes<struct ArrowArrayStream>;
+    ERL_NIF_TERM error{};
+
+    res_type * res = nullptr;
+    if ((res = res_type::get_resource(env, argv[0], error)) == nullptr) {
+        return error;
+    }
+    if (res->val.get_next == nullptr) {
+        
+    }
+
+    struct ArrowArray out{};
+    int code = res->val.get_next(&res->val, &out);
+    if (code != 0) {
+        const char * reason = res->val.get_last_error(&res->val);
+        return erlang::nif::error(env, reason ? reason : "unknown error");
+    }
+
+    // TODO: convert out ArrowArray to elixir values    
+
+    return erlang::nif::ok(env);
+}
+
 static ERL_NIF_TERM adbc_arrow_array_stream_release(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     using res_type = NifRes<struct ArrowArrayStream>;
     ERL_NIF_TERM error{};
@@ -1160,6 +1184,7 @@ static ErlNifFunc nif_functions[] = {
 
     {"adbc_arrow_array_stream_get_pointer", 1, adbc_arrow_array_stream_get_pointer, 0},
     {"adbc_arrow_array_stream_get_schema", 1, adbc_arrow_array_stream_get_schema, 0},
+    {"adbc_arrow_array_stream_next", 1, adbc_arrow_array_stream_next, 0},
     {"adbc_arrow_array_stream_release", 1, adbc_arrow_array_stream_release, 0},
 
     {"adbc_error_new", 0, adbc_error_new, 0},

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -172,9 +172,6 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
         return erlang::nif::error(env, "invalid ArrowArray, values->children == nullptr, however, values->n_children > 0");
     }
     if (values->n_children != schema->n_children) {
-        printf("values->n_children: %lld\r\n", values->n_children);
-        printf("schema->n_children: %lld\r\n", schema->n_children);
-        printf("not implemented for format: `%s`\r\n", schema->format);
         return erlang::nif::error(env, "invalid ArrowArray or ArrowSchema, values->n_children != schema->n_children");
     }
 
@@ -188,7 +185,7 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
     }
     children_term = enif_make_list_from_array(env, children.data(), (unsigned)schema->n_children);
 
-    ERL_NIF_TERM current_term = erlang::nif::error(env, "not implemented");
+    ERL_NIF_TERM current_term{};
 
     bool has_validity_bitmap = values->null_count != 0 && values->null_count != -1;
     const uint8_t * bitmap_buffer = nullptr;
@@ -307,7 +304,10 @@ static ERL_NIF_TERM arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema *
         // only handle and return children if this is a struct
         is_struct = true;
     } else {
-        printf("not implemented for format: `%s`\r\n", schema->format);
+        char buf[256] = { '\0' };
+        snprintf(buf, 256, "not implemented for format: `%s`", schema->format);
+        children_term = erlang::nif::error(env, buf);
+        // printf("not implemented for format: `%s`\r\n", schema->format);
         // printf("length: %lld\r\n", values->length);
         // printf("null_count: %lld\r\n", values->null_count);
         // printf("offset: %lld\r\n", values->offset);

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -1272,7 +1272,6 @@ static ErlNifFunc nif_functions[] = {
     {"adbc_statement_set_sql_query", 2, adbc_statement_set_sql_query, 0},
     {"adbc_statement_bind", 2, adbc_statement_bind, 0},
     {"adbc_statement_bind_stream", 2, adbc_statement_bind_stream, 0},
-    {"adbc_statement_get_parameter_schema", 1, adbc_statement_get_parameter_schema, 0},
 
     {"adbc_arrow_array_stream_get_pointer", 1, adbc_arrow_array_stream_get_pointer, 0},
     {"adbc_arrow_array_stream_get_schema", 1, adbc_arrow_array_stream_get_schema, 0},

--- a/lib/adbc_arrow_array_stream.ex
+++ b/lib/adbc_arrow_array_stream.ex
@@ -43,6 +43,11 @@ defmodule Adbc.ArrowArrayStream do
     end
   end
 
+  @spec next(Adbc.ArrowArrayStream.t()) :: term() | {:error, String.t()}
+  def next(self = %T{}) do
+    Adbc.Nif.adbc_arrow_array_stream_release(self.reference)
+  end
+
   @spec release(Adbc.ArrowArrayStream.t()) :: :ok | {:error, String.t()}
   def release(self = %T{}) do
     Adbc.Nif.adbc_arrow_array_stream_release(self.reference)

--- a/lib/adbc_arrow_array_stream.ex
+++ b/lib/adbc_arrow_array_stream.ex
@@ -15,9 +15,30 @@ defmodule Adbc.ArrowArrayStream do
         }
   defstruct [:reference, :pointer]
   alias __MODULE__, as: T
+  alias Adbc.ArrowSchema
 
   @spec get_pointer(Adbc.ArrowArrayStream.t()) :: non_neg_integer()
   def get_pointer(self = %T{}) do
     Adbc.Nif.adbc_arrow_array_stream_get_pointer(self.reference)
+  end
+
+  @spec get_schema(Adbc.ArrowArrayStream.t()) ::
+          {:ok, Adbc.ArrowSchema.t()} | {:error, String.t()} | Adbc.Error.adbc_error()
+  def get_schema(self = %T{}) do
+    case Adbc.Nif.adbc_arrow_array_stream_get_schema(self.reference) do
+      {:ok, schema_ref, {format, name, metadata, flags, n_children}} ->
+        {:ok,
+         %ArrowSchema{
+           format: format,
+           name: name,
+           metadata: metadata,
+           flags: flags,
+           n_children: n_children,
+           reference: schema_ref
+         }}
+
+      other ->
+        other
+    end
   end
 end

--- a/lib/adbc_arrow_array_stream.ex
+++ b/lib/adbc_arrow_array_stream.ex
@@ -45,7 +45,7 @@ defmodule Adbc.ArrowArrayStream do
 
   @spec next(Adbc.ArrowArrayStream.t()) :: term() | {:error, String.t()}
   def next(self = %T{}) do
-    Adbc.Nif.adbc_arrow_array_stream_release(self.reference)
+    Adbc.Nif.adbc_arrow_array_stream_next(self.reference)
   end
 
   @spec release(Adbc.ArrowArrayStream.t()) :: :ok | {:error, String.t()}

--- a/lib/adbc_arrow_array_stream.ex
+++ b/lib/adbc_arrow_array_stream.ex
@@ -26,7 +26,7 @@ defmodule Adbc.ArrowArrayStream do
           {:ok, Adbc.ArrowSchema.t()} | {:error, String.t()} | Adbc.Error.adbc_error()
   def get_schema(self = %T{}) do
     case Adbc.Nif.adbc_arrow_array_stream_get_schema(self.reference) do
-      {:ok, schema_ref, {format, name, metadata, flags, n_children}} ->
+      {:ok, schema_ref, {format, name, metadata, flags, n_children, children}} ->
         {:ok,
          %ArrowSchema{
            format: format,
@@ -34,6 +34,7 @@ defmodule Adbc.ArrowArrayStream do
            metadata: metadata,
            flags: flags,
            n_children: n_children,
+           children: Enum.map(children, &ArrowSchema.from_metainfo/1),
            reference: schema_ref
          }}
 

--- a/lib/adbc_arrow_array_stream.ex
+++ b/lib/adbc_arrow_array_stream.ex
@@ -42,4 +42,9 @@ defmodule Adbc.ArrowArrayStream do
         other
     end
   end
+
+  @spec release(Adbc.ArrowArrayStream.t()) :: :ok | {:error, String.t()}
+  def release(self = %T{}) do
+    Adbc.Nif.adbc_arrow_array_stream_release(self.reference)
+  end
 end

--- a/lib/adbc_arrow_schema.ex
+++ b/lib/adbc_arrow_schema.ex
@@ -4,13 +4,99 @@ defmodule Adbc.ArrowSchema do
   """
 
   @typedoc """
+  - **format**: `String.t()`
+
+    A null-terminated, UTF8-encoded string describing the data type.
+
+    If the data type is nested, child types are not encoded here but
+    in the ArrowSchema.children structures.
+
+    Consumers MAY decide not to support all data types, but they should
+    document this limitation.
+
+  - **name**: `String.t()`
+
+    A null-terminated, UTF8-encoded string of the field or array name.
+    This is mainly used to reconstruct child fields of nested types.
+
+    Producers MAY decide not to provide this information, and consumers
+    MAY decide to ignore it. If omitted, MAY be NULL or an empty string.
+
+  - **metadata**: `String.t()` | nil
+
+    A binary string describing the type’s metadata. If the data type is
+    nested, child types are not encoded here but in the ArrowSchema.children
+    structures.
+
+    This string is not null-terminated but follows a specific format:
+
+    ```
+    int32: number of key/value pairs (noted N below)
+    int32: byte length of key 0
+    key 0 (not null-terminated)
+    int32: byte length of value 0
+    value 0 (not null-terminated)
+    ...
+    int32: byte length of key N - 1
+    key N - 1 (not null-terminated)
+    int32: byte length of value N - 1
+    value N - 1 (not null-terminated)
+    ```
+
+    Integers are stored in native endianness. For example, the metadata
+    `[('key1', 'value1')]` is encoded on a little-endian machine as:
+
+    ```
+    \x01\x00\x00\x00\x04\x00\x00\x00key1\x06\x00\x00\x00value1
+    ```
+
+    On a big-endian machine, the same example would be encoded as:
+
+    ```
+    \x00\x00\x00\x01\x00\x00\x00\x04key1\x00\x00\x00\x06value1
+    ```
+
+    If omitted, this field MUST be `nil` (not an empty string).
+
+    Consumers MAY choose to ignore this information.
+
+  - **flags**: `integer()`
+
+    A bitfield of flags enriching the type description. Its value
+    is computed by OR’ing together the flag values. The following
+    flags are available:
+
+    - `2` (ARROW_FLAG_NULLABLE): whether this field is semantically nullable
+      (regardless of whether it actually has null values).
+
+    - `1` (ARROW_FLAG_DICTIONARY_ORDERED): for dictionary-encoded types,
+      whether the ordering of dictionary indices is semantically meaningful.
+
+    - `4` (ARROW_FLAG_MAP_KEYS_SORTED): for map types, whether the keys within
+      each map value are sorted.
+
+    If omitted, MUST be 0.
+
+    Consumers MAY choose to ignore some or all of the flags. Even then, they
+    SHOULD keep this value around so as to propagate its information to their
+    own consumers.
+
+  - **n_children**: `integer()`
+
+    The number of children this type has.
+
   - **reference**: `reference`.
 
     The underlying erlang resource variable.
 
   """
   @type t :: %__MODULE__{
+          format: String.t(),
+          name: String.t(),
+          metadata: String.t(),
+          flags: integer(),
+          n_children: integer(),
           reference: reference()
         }
-  defstruct [:reference]
+  defstruct [:format, :name, :metadata, :flags, :n_children, :reference]
 end

--- a/lib/adbc_arrow_schema.ex
+++ b/lib/adbc_arrow_schema.ex
@@ -96,7 +96,20 @@ defmodule Adbc.ArrowSchema do
           metadata: String.t(),
           flags: integer(),
           n_children: integer(),
+          children: [Adbc.ArrowSchema.t() | {:error, String.t()}],
           reference: reference()
         }
-  defstruct [:format, :name, :metadata, :flags, :n_children, :reference]
+  defstruct [:format, :name, :metadata, :flags, :n_children, :children, :reference]
+  alias __MODULE__, as: T
+
+  def from_metainfo({format, name, metadata, flags, n_children, children}) do
+    %T{
+      format: format,
+      name: name,
+      metadata: metadata,
+      flags: flags,
+      n_children: n_children,
+      children: Enum.map(children, &from_metainfo/1)
+    }
+  end
 end

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -191,13 +191,13 @@ defmodule Adbc.Connection do
     case GenServer.call(conn, {:get_table_schema, catalog, db_schema, table_name}, :infinity) do
       {:ok, schema_ref, {format, name, metadata, flags, n_children, children}} ->
         {:ok,
-           %ArrowSchema{
+           %Adbc.ArrowSchema{
              format: format,
              name: name,
              metadata: metadata,
              flags: flags,
              n_children: n_children,
-             children: Enum.map(children, &ArrowSchema.from_metainfo/1),
+             children: Enum.map(children, &Adbc.ArrowSchema.from_metainfo/1),
              reference: schema_ref
         }}
       {:error, reason} -> {:error, error_to_exception(reason)}

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -282,15 +282,17 @@ defmodule Adbc.Connection do
       when (is_binary(catalog) or catalog == nil) and (is_binary(db_schema) or catalog == nil) and
              is_binary(table_name) do
     case Adbc.Nif.adbc_connection_get_table_schema(self.reference, catalog, db_schema, table_name) do
-      {:ok, schema_ref, {format, name, metadata, flags, n_children}} ->
-        {:ok, %ArrowSchema{
-          format: format,
-          name: name,
-          metadata: metadata,
-          flags: flags,
-          n_children: n_children,
-          reference: schema_ref
-        }}
+      {:ok, schema_ref, {format, name, metadata, flags, n_children, children}} ->
+        {:ok,
+         %ArrowSchema{
+           format: format,
+           name: name,
+           metadata: metadata,
+           flags: flags,
+           n_children: n_children,
+           children: Enum.map(children, &ArrowSchema.from_metainfo/1),
+           reference: schema_ref
+         }}
 
       {:error, {reason, code, sql_state}} ->
         {:error, {reason, code, sql_state}}

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -5,7 +5,6 @@ defmodule Adbc.Connection do
 
   @type t :: GenServer.server()
 
-
   use GenServer
   import Adbc.Helper, only: [error_to_exception: 1]
 
@@ -166,15 +165,14 @@ defmodule Adbc.Connection do
       when is_integer(depth) and depth >= 0 do
     opts = Keyword.validate!(opts, [:catalog, :db_schema, :table_name, :table_type, :column_name])
 
-    args =
-      [
-        depth,
-        opts[:catalog],
-        opts[:db_schema],
-        opts[:table_name],
-        opts[:table_type],
-        opts[:column_name]
-      ]
+    args = [
+      depth,
+      opts[:catalog],
+      opts[:db_schema],
+      opts[:table_name],
+      opts[:table_type],
+      opts[:column_name]
+    ]
 
     stream_lock(conn, {:adbc_connection_get_objects, args}, fun)
   end
@@ -204,16 +202,20 @@ defmodule Adbc.Connection do
       when (is_binary(catalog) or catalog == nil) and (is_binary(db_schema) or catalog == nil) and
              is_binary(table_name) do
     case queue(conn, {:adbc_connection_get_table_schema, [catalog, db_schema, table_name]}) do
-      {:ok, schema_ref, {format, name, metadata, flags, n_children, children}} -> {:ok, %Adbc.%Adbc.ArrowSchema{
-             format: format,
-             name: name,
-             metadata: metadata,
-             flags: flags,
-             n_children: n_children,
-             children: Enum.map(children, &Adbc.ArrowSchema.from_metainfo/1),
-             reference: schema_ref
-        }}
-      {:error, reason} -> {:error, error_to_exception(reason)}
+      {:ok, schema_ref, {format, name, metadata, flags, n_children, children}} ->
+        {:ok,
+         %Adbc.ArrowSchema{
+           format: format,
+           name: name,
+           metadata: metadata,
+           flags: flags,
+           n_children: n_children,
+           children: Enum.map(children, &Adbc.ArrowSchema.from_metainfo/1),
+           reference: schema_ref
+         }}
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
     end
   end
 

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -282,8 +282,15 @@ defmodule Adbc.Connection do
       when (is_binary(catalog) or catalog == nil) and (is_binary(db_schema) or catalog == nil) and
              is_binary(table_name) do
     case Adbc.Nif.adbc_connection_get_table_schema(self.reference, catalog, db_schema, table_name) do
-      {:ok, schema_ref} ->
-        {:ok, %ArrowSchema{reference: schema_ref}}
+      {:ok, schema_ref, {format, name, metadata, flags, n_children}} ->
+        {:ok, %ArrowSchema{
+          format: format,
+          name: name,
+          metadata: metadata,
+          flags: flags,
+          n_children: n_children,
+          reference: schema_ref
+        }}
 
       {:error, {reason, code, sql_state}} ->
         {:error, {reason, code, sql_state}}

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -14,7 +14,6 @@ defmodule Adbc.Connection do
         }
   defstruct [:reference]
   alias __MODULE__, as: T
-  alias Adbc.Database
   alias Adbc.ArrowArrayStream
   alias Adbc.ArrowSchema
   alias Adbc.Helper

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -83,6 +83,7 @@ defmodule Adbc.Nif do
 
   def adbc_arrow_array_stream_get_pointer(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
   def adbc_arrow_array_stream_get_schema(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
+  def adbc_arrow_array_stream_release(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 
   def adbc_error_new(), do: :erlang.nif_error(:not_loaded)
   def adbc_error_reset(_error), do: :erlang.nif_error(:not_loaded)

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -83,6 +83,7 @@ defmodule Adbc.Nif do
 
   def adbc_arrow_array_stream_get_pointer(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
   def adbc_arrow_array_stream_get_schema(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
+  def adbc_arrow_array_stream_next(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
   def adbc_arrow_array_stream_release(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 
   def adbc_error_new(), do: :erlang.nif_error(:not_loaded)

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -82,6 +82,7 @@ defmodule Adbc.Nif do
   def adbc_statement_get_parameter_schema(_statement), do: :erlang.nif_error(:not_loaded)
 
   def adbc_arrow_array_stream_get_pointer(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
+  def adbc_arrow_array_stream_get_schema(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 
   def adbc_error_new(), do: :erlang.nif_error(:not_loaded)
   def adbc_error_reset(_error), do: :erlang.nif_error(:not_loaded)

--- a/lib/adbc_statement.ex
+++ b/lib/adbc_statement.ex
@@ -11,7 +11,6 @@ defmodule Adbc.Statement do
   defstruct [:reference]
   alias __MODULE__, as: T
   alias Adbc.ArrowArrayStream
-  alias Adbc.ArrowSchema
 
   @doc """
   Create a new statement for a given connection.

--- a/test.exs
+++ b/test.exs
@@ -3,6 +3,8 @@ alias Adbc.Connection
 alias Adbc.Statement
 alias Adbc.ArrowArrayStream
 
+Adbc.Driver.download_driver(:sqlite)
+
 {:ok, db} = Adbc.Database.start_link(driver: :sqlite)
 {:ok, %Connection{} = conn} = Database.connection(db)
 
@@ -11,17 +13,25 @@ alias Adbc.ArrowArrayStream
 {:ok, _stream, _row_affected} = Statement.execute_query(statement)
 
 :ok = Statement.set_sql_query(statement, "INSERT INTO foo(i64,f64,str) VALUES(?,?,?)")
-r = :rand.uniform(1000)
-:ok = Statement.bind(statement, [r, r * 1.1, "value = #{inspect(r)}"])
+i64_1 = :rand.uniform(1000)
+f64_1 = i64_1 * 1.1
+str_1 = "value = #{inspect(i64_1)}"
+:ok = Statement.bind(statement, [i64_1, f64_1, str_1])
 {:ok, _stream, _row_affected} = Statement.execute_query(statement)
 :ok = Statement.set_sql_query(statement, "INSERT INTO foo(i64,f64,str) VALUES(?,?,?)")
-r = :rand.uniform(1000)
-:ok = Statement.bind(statement, [r, r * 1.1, "value = #{inspect(r)}"])
+i64_2 = :rand.uniform(1000)
+f64_2 = i64_2 * 1.1
+str_2 = "value = #{inspect(i64_2)}"
+:ok = Statement.bind(statement, [i64_2, f64_2, str_2])
 {:ok, _stream, _row_affected} = Statement.execute_query(statement)
 
 {:ok, statement} = Statement.new(conn)
 :ok = Statement.set_sql_query(statement, "SELECT * FROM foo")
 {:ok, stream, _row_affected} = Statement.execute_query(statement)
-# IO.inspect(stream)
-{:ok, schema} = ArrowArrayStream.get_schema(stream)
-IO.inspect(schema)
+{:ok, next} = ArrowArrayStream.next(stream)
+IO.inspect(next)
+[
+  {"i64", [^i64_1, ^i64_2]},
+  {"f64", [^f64_1, ^f64_2]},
+  {"str", [^str_1, ^str_2]}
+] = next

--- a/test.exs
+++ b/test.exs
@@ -5,8 +5,10 @@ alias Adbc.ArrowArrayStream
 
 Adbc.Driver.download_driver(:sqlite)
 
-{:ok, db} = Adbc.Database.start_link(driver: :sqlite)
-{:ok, %Connection{} = conn} = Database.connection(db)
+{:ok, db} = Database.start_link(driver: :sqlite)
+{:ok, conn} = Connection.start_link(database: db)
+
+conn = %{reference: :sys.get_state(conn).conn}
 
 {:ok, statement} = Statement.new(conn)
 :ok = Statement.set_sql_query(statement, "CREATE TABLE IF NOT EXISTS foo (i64 INT, f64 REAL, str TEXT)")

--- a/test.exs
+++ b/test.exs
@@ -1,0 +1,30 @@
+alias Adbc.Database
+alias Adbc.Connection
+alias Adbc.Statement
+alias Adbc.ArrowArrayStream
+
+{:ok, database} = Database.new()
+Database.set_option(database, "driver", "adbc_driver_sqlite")
+Database.init(database)
+
+{:ok, connection} = Connection.new()
+:ok = Connection.init(connection, database)
+
+{:ok, statement} = Statement.new(connection)
+:ok = Statement.set_sql_query(statement, "CREATE TABLE IF NOT EXISTS foo (i64 INT, f64 REAL, str TEXT)")
+{:ok, _stream, _row_affected} = Statement.execute_query(statement)
+
+:ok = Statement.set_sql_query(statement, "INSERT INTO foo(i64,f64,str) VALUES(?,?,?)")
+r = :rand.uniform(1000)
+:ok = Statement.bind(statement, [r, r * 1.1, "value = #{inspect(r)}"])
+{:ok, _stream, _row_affected} = Statement.execute_query(statement)
+:ok = Statement.set_sql_query(statement, "INSERT INTO foo(i64,f64,str) VALUES(?,?,?)")
+r = :rand.uniform(1000)
+:ok = Statement.bind(statement, [r, r * 1.1, "value = #{inspect(r)}"])
+{:ok, _stream, _row_affected} = Statement.execute_query(statement)
+
+{:ok, statement} = Statement.new(connection)
+:ok = Statement.set_sql_query(statement, "SELECT * FROM foo")
+{:ok, stream, _row_affected} = Statement.execute_query(statement)
+{:ok, schema} = ArrowArrayStream.get_schema(stream)
+IO.inspect(schema)

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -35,8 +35,7 @@ defmodule Adbc.Connection.Test do
     test "errors with invalid option", %{db: db} do
       Process.flag(:trap_exit, true)
 
-      assert {:error, %Adbc.Error{} = error} =
-               Connection.start_link(database: db, who_knows: 123)
+      assert {:error, %Adbc.Error{} = error} = Connection.start_link(database: db, who_knows: 123)
 
       assert Exception.message(error) == "[SQLite] Unknown connection option who_knows=123"
     end

--- a/test/adbc_statement_test.exs
+++ b/test/adbc_statement_test.exs
@@ -106,5 +106,7 @@ defmodule Adbc.Statement.Test do
       {"f64", [42.0]},
       {"str", ["value = 42"]}
     ] == next
+
+    Statement.release(statement)
   end
 end

--- a/test/adbc_statement_test.exs
+++ b/test/adbc_statement_test.exs
@@ -63,7 +63,13 @@ defmodule Adbc.Statement.Test do
   test "query values", %{conn: conn, test: test} do
     {:ok, %Statement{} = statement} = Statement.new(conn)
     assert is_reference(statement.reference)
-    assert :ok == Statement.set_sql_query(statement, "CREATE TABLE \"#{test}\" (i64 INT, f64 REAL, str TEXT)")
+
+    assert :ok ==
+             Statement.set_sql_query(
+               statement,
+               "CREATE TABLE \"#{test}\" (i64 INT, f64 REAL, str TEXT)"
+             )
+
     {:ok, _stream, row_affected} = Statement.execute_query(statement)
     assert row_affected == -1
 
@@ -89,22 +95,24 @@ defmodule Adbc.Statement.Test do
     {:ok, stream, row_affected} = Statement.execute_query(statement)
     assert row_affected == -1
     {:ok, next} = ArrowArrayStream.next(stream)
+
     assert [
-      {"i64", [43, 44]},
-      {"f64", [43.0, 44.0]},
-      {"str", ["value = 43", "value = 44"]}
-    ] == next
+             {"i64", [43, 44]},
+             {"f64", [43.0, 44.0]},
+             {"str", ["value = 43", "value = 44"]}
+           ] == next
 
     assert :ok == Statement.set_sql_query(statement, "SELECT * FROM \"#{test}\" WHERE i64 = ?")
     assert :ok == Statement.bind(statement, [42])
     {:ok, stream, row_affected} = Statement.execute_query(statement)
     assert row_affected == -1
     {:ok, next} = ArrowArrayStream.next(stream)
+
     assert [
-      {"i64", [42]},
-      {"f64", [42.0]},
-      {"str", ["value = 42"]}
-    ] == next
+             {"i64", [42]},
+             {"f64", [42.0]},
+             {"str", ["value = 42"]}
+           ] == next
 
     Statement.release(statement)
   end

--- a/test/adbc_statement_test.exs
+++ b/test/adbc_statement_test.exs
@@ -2,7 +2,6 @@ defmodule Adbc.Statement.Test do
   use ExUnit.Case
   doctest Adbc.Statement
 
-  alias Adbc.Connection
   alias Adbc.Database
   alias Adbc.Statement
 


### PR DESCRIPTION
This PR added support for parsing ArrowSchema and convert ArrowArray to Elixir values in NIF. Formats listed below are supported

| format | description |
|-------|------------|
| `l` | `int64_t` |
| `c` | `int8_t` |
| `s` | `int16_t` |
| `i` | `int32_t` |
| `L` | `uint64_t` |
| `C` | `uint8_t` |
| `S` | `uint16_t` |
| `I` | `uint32_t` |
| `f` | `float` |
| `g` | `double` |
| `u` | `string` |
| `+s` | `struct` |